### PR TITLE
Add built-in search plugin to config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ nav:
     - Foo: borgs/foo.md
 
 plugins:
+  - search
   - section-index
 ```
 


### PR DESCRIPTION
When I copied the config example here, the search box disappeared from my output.

After a bit of research, I found this in the [Material theme docs](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#built-in-search-plugin):

> The built-in search plugin integrates seamlessly with Material for MkDocs, adding multilingual client-side search with lunr and lunr-languages. It's enabled by default, but must be re-added to `mkdocs.yml` when other plugins are used

To prevent confusion, I've added that line to the config example.